### PR TITLE
Downgrade TypeScript and remove direction toggle background

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16338,9 +16338,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -16348,7 +16348,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -124,7 +124,7 @@ button:hover { background: var(--brand-secondary, #00cc52); }
 
 .status { margin-top: 15px; font-size: 14px; color: var(--brand-primary, #00ff66); }
 
-.direction-toggle { display: inline-flex; align-items: center; justify-content: center; margin: 2px auto; width: 36px; height: 36px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.08); background: color-mix(in srgb, var(--brand-primary), #000 80%); color: #fff; }
+.direction-toggle { display: inline-flex; align-items: center; justify-content: center; margin: 2px auto; width: 36px; height: 36px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.08); color: #fff; }
 .direction-toggle:hover { filter: brightness(1.1); }
 
 .amount-field { position: relative; width: 100%; }


### PR DESCRIPTION
## Purpose
Based on the conversation context referencing visual changes in App.js, this PR addresses compatibility and styling adjustments to improve the application's appearance and dependency management.

## Code changes
- **TypeScript downgrade**: Downgraded TypeScript from version 5.9.2 to 4.9.5 in package-lock.json, adjusting Node.js engine requirement from >=14.17 to >=4.2.0
- **UI styling update**: Removed background color styling from `.direction-toggle` class in App.css, keeping the circular button design but removing the color-mix background propertyTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/35d495b5c7f542c0860da177410c3894/zen-hub)

👀 [Preview Link](https://35d495b5c7f542c0860da177410c3894-zen-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>35d495b5c7f542c0860da177410c3894</projectId>-->
<!--<branchName>zen-hub</branchName>-->