### PR TITLE
Provide placeholder Keeta SDK for Netlify builds

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@keeta/sdk": "*",
+    "@keeta/sdk": "file:./vendor/keeta-sdk",
     "sharp": "^0.33.3"
   }
 }

--- a/functions/swap.js
+++ b/functions/swap.js
@@ -4,13 +4,20 @@ let RealKeetaClientCtor = null;
 try {
   // Support different export styles from the SDK (CommonJS / ESM default exports).
   const maybeModule = require("@keeta/sdk");
+  const candidateCtors = [];
   if (typeof maybeModule === "function") {
-    RealKeetaClientCtor = maybeModule;
-  } else if (maybeModule && typeof maybeModule.KeetaClient === "function") {
-    RealKeetaClientCtor = maybeModule.KeetaClient;
-  } else if (maybeModule && typeof maybeModule.default === "function") {
-    RealKeetaClientCtor = maybeModule.default;
+    candidateCtors.push(maybeModule);
   }
+  if (maybeModule && typeof maybeModule.KeetaClient === "function") {
+    candidateCtors.push(maybeModule.KeetaClient);
+  }
+  if (maybeModule && typeof maybeModule.default === "function") {
+    candidateCtors.push(maybeModule.default);
+  }
+
+  RealKeetaClientCtor = candidateCtors.find(
+    (ctor) => typeof ctor === "function" && ctor.__isKeetaPlaceholder !== true
+  );
 } catch (err) {
   // The SDK is optional for local development; fall back to a mock client below.
   RealKeetaClientCtor = null;

--- a/functions/vendor/keeta-sdk/index.js
+++ b/functions/vendor/keeta-sdk/index.js
@@ -1,0 +1,22 @@
+class PlaceholderKeetaClient {
+  constructor(config = {}) {
+    this.config = { ...config };
+    Object.defineProperty(this, "__isKeetaPlaceholder", {
+      value: true,
+      enumerable: false,
+      configurable: false,
+    });
+  }
+
+  async swap() {
+    throw new Error(
+      "@keeta/sdk is not available in this environment. Install the private Keeta SDK to enable real swaps."
+    );
+  }
+}
+
+module.exports = {
+  KeetaClient: PlaceholderKeetaClient,
+  default: PlaceholderKeetaClient,
+  __isKeetaPlaceholder: true,
+};

--- a/functions/vendor/keeta-sdk/package.json
+++ b/functions/vendor/keeta-sdk/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@keeta/sdk",
+  "version": "0.0.0-placeholder",
+  "description": "Placeholder Keeta SDK to allow building without private package access.",
+  "main": "index.js",
+  "license": "UNLICENSED",
+  "private": true
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "client/build"
-  command = "npm install --prefix client && npm run build --prefix client"
+  command = "npm install --prefix functions && npm install --prefix client && npm run build --prefix client"
 
 [functions]
   directory = "functions"


### PR DESCRIPTION
## Summary
- vendor a placeholder `@keeta/sdk` package that can be bundled without private registry access
- point the Netlify functions package.json at the vendored SDK and detect placeholders before using the real client

## Testing
- `npm install --prefix functions` *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/sharp)*

------
https://chatgpt.com/codex/tasks/task_e_68d364a948048328999ed67193a96cd3