### PR TITLE
Close token selector on selection

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -51,18 +51,45 @@ function TokenSelect({ value, onChange, options }) {
     () => options.filter((o) => o.toLowerCase().includes(query.toLowerCase())),
     [options, query]
   );
+
+  const closePopover = () => {
+    setOpen(false);
+    setQuery("");
+  };
+
+  const handleSelect = (sym) => {
+    onChange(sym);
+    closePopover();
+  };
+
   return (
     <div className="token-select-wrap">
-      <button type="button" className="token-pill" onClick={() => setOpen((v) => !v)} aria-haspopup="listbox" aria-expanded={open}>
+      <button
+        type="button"
+        className="token-pill"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
         <span className="token-icon"><TokenBadge symbol={value} /></span>
         <span className="token-symbol">{value}</span>
       </button>
       {open && (
         <div className="token-popover" role="listbox">
-          <input className="token-search" placeholder="Search token" value={query} onChange={(e) => setQuery(e.target.value)} />
+          <input
+            className="token-search"
+            placeholder="Search token"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
           <div className="token-list">
             {filtered.map((sym) => (
-              <button key={sym} type="button" className={`token-item${sym === value ? " is-active" : ""}`} onClick={() => { onChange(sym); setOpen(false); }}>
+              <button
+                key={sym}
+                type="button"
+                className={`token-item${sym === value ? " is-active" : ""}`}
+                onClick={() => handleSelect(sym)}
+              >
                 <span className="token-icon"><TokenBadge symbol={sym} /></span>
                 <span className="token-symbol">{sym}</span>
               </button>


### PR DESCRIPTION
## Summary
- close the custom token selector popover whenever a token option is chosen
- reset the token search query after closing so the next open starts unfiltered

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d376e2847483289c840a4acb0ded84