### PR TITLE
Adjust swap toggle icon and refresh token art

### DIFF
--- a/client/public/tokens/btc.svg
+++ b/client/public/tokens/btc.svg
@@ -1,4 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <circle cx="32" cy="32" r="32" fill="#F7931A"/>
-  <path fill="#FFFFFF" d="M37.6 33.9c2-.8 3.3-2.6 3.3-4.9 0-3.6-2.9-6.1-7.6-6.1h-1.2v-4.6h-4.2v4.5h-3v4.1h3v9.5h-3v4.1h3V45h4.2v-4.5h1.7c4.9 0 7.9-2.5 7.9-6.6 0-2.5-1.1-4.2-3.1-5zm-5.6-6.3c1.9 0 3.1.9 3.1 2.4s-1.2 2.4-3.1 2.4h-1.4v-4.8zm.6 13.1h-2v-5h2.1c2.2 0 3.5 1 3.5 2.6 0 1.7-1.3 2.4-3.6 2.4z"/>
+  <defs>
+    <radialGradient id="btcBg" cx="50%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="#FFC76A"/>
+      <stop offset="100%" stop-color="#F7931A"/>
+    </radialGradient>
+    <linearGradient id="btcHighlight" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="30" fill="url(#btcBg)"/>
+  <circle cx="32" cy="32" r="28" fill="none" stroke="#FFFFFF" stroke-opacity="0.25" stroke-width="2"/>
+  <path fill="url(#btcHighlight)" d="M32 6a26 26 0 1026 26A26 26 0 0032 6z"/>
+  <g fill="#FFFFFF">
+    <path d="M38.3 32.9c2.2-.9 3.6-2.9 3.6-5.5 0-4.3-3.3-6.9-8.8-6.9h-1.3v-4.3H28V20h-3.3v3.4H28v15.2h-3.3V42H28v4.2h3.8V42h2c5.8 0 9.2-2.9 9.2-7.4 0-2.9-1.4-5-3.7-6.2zm-5-8.5c2.6 0 4.2 1.2 4.2 3.1s-1.6 3.1-4.2 3.1h-2.1v-6.2zm.4 13.3H33v-6.3h2.3c3 0 4.7 1.3 4.7 3.4 0 2.2-1.6 2.9-4.3 2.9z"/>
+  </g>
 </svg>

--- a/client/public/tokens/eth.svg
+++ b/client/public/tokens/eth.svg
@@ -1,15 +1,32 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <linearGradient id="ethTop" x1="50%" y1="0%" x2="50%" y2="100%">
-    <stop offset="0%" stop-color="#8A92B2"/>
-    <stop offset="100%" stop-color="#62688F"/>
-  </linearGradient>
-  <linearGradient id="ethBottom" x1="50%" y1="0%" x2="50%" y2="100%">
-    <stop offset="0%" stop-color="#34384C"/>
-    <stop offset="100%" stop-color="#0D0F1A"/>
-  </linearGradient>
-  <rect width="64" height="64" rx="12" fill="#10131F"/>
-  <g transform="translate(32 12)">
-    <path fill="url(#ethTop)" d="M0 0l-10.5 17.5L0 24l10.5-6.5z"/>
-    <path fill="url(#ethBottom)" d="M-10.5 23.7L0 31l10.5-7.3L0 37z"/>
+  <defs>
+    <linearGradient id="ethBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#141A2C"/>
+      <stop offset="100%" stop-color="#090B16"/>
+    </linearGradient>
+    <linearGradient id="ethTop" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#8A92B2"/>
+      <stop offset="100%" stop-color="#62688F"/>
+    </linearGradient>
+    <linearGradient id="ethMiddle" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#3E4257"/>
+      <stop offset="100%" stop-color="#1B1D2A"/>
+    </linearGradient>
+    <linearGradient id="ethBottom" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#303244"/>
+      <stop offset="100%" stop-color="#0D0E16"/>
+    </linearGradient>
+    <linearGradient id="ethHighlight" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="url(#ethBg)"/>
+  <g transform="translate(0 -2)">
+    <polygon points="32 12 18 34 32 27.5 46 34" fill="url(#ethTop)"/>
+    <polygon points="18 34 32 42 46 34 32 27.5" fill="url(#ethMiddle)"/>
+    <polygon points="18 36 32 58 46 36 32 44" fill="url(#ethBottom)"/>
+    <polygon points="32 12 18 34 32 27.5" fill="url(#ethHighlight)"/>
+    <polygon points="32 12 46 34 32 27.5" fill="url(#ethHighlight)" opacity="0.35"/>
   </g>
 </svg>

--- a/client/public/tokens/kusd.svg
+++ b/client/public/tokens/kusd.svg
@@ -1,11 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <linearGradient id="kusdGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#2BB673"/>
-      <stop offset="100%" stop-color="#0B8E46"/>
+    <linearGradient id="kusdBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#32D17C"/>
+      <stop offset="100%" stop-color="#0E8F4B"/>
+    </linearGradient>
+    <linearGradient id="kusdInner" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0"/>
     </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="12" fill="url(#kusdGradient)"/>
-  <circle cx="32" cy="32" r="18" fill="#FFFFFF" fill-opacity="0.25"/>
-  <path fill="#FFFFFF" d="M32 20c-6.6 0-12 4.4-12 10s5.4 10 12 10c3 0 5.7-.8 7.9-2.4l-3.4-3.4a7.6 7.6 0 01-4.5 1.4c-3.3 0-5.8-1.9-5.8-4.7s2.5-4.7 5.8-4.7c1.5 0 2.9.4 4 1.2V32h4.7v-9.7A15.8 15.8 0 0032 20zm-2.1 17.7l-2.9 2.9 5 5 2.9-2.9-5-5z"/>
+  <rect width="64" height="64" rx="16" fill="url(#kusdBg)"/>
+  <circle cx="32" cy="32" r="22" fill="none" stroke="#FFFFFF" stroke-opacity="0.3" stroke-width="3"/>
+  <path fill="url(#kusdInner)" d="M32 10a22 22 0 1022 22A22 22 0 0032 10z"/>
+  <g fill="#FFFFFF">
+    <path d="M22 20v24h4.5V33.8l12.3 10.2H44L31 31.8l12.5-11.8h-5.4L26.5 28V20H22z"/>
+    <path d="M41 36.2c0 3.7-3.1 6.3-7.6 6.3-2.7 0-5.2-.9-7.3-2.6l-2.1 3.2c2.6 2.1 6 3.3 9.5 3.3 7 0 11.7-4.2 11.7-10.5 0-4.8-3.1-7.9-8.8-8.9l-3.8-.7c-2.9-.5-4.1-1.4-4.1-3 0-1.9 1.8-3.2 4.5-3.2 2.3 0 4.3.7 6 1.9l1.9-3.2c-1.9-1.3-4.5-2.2-7.5-2.4V16h-4v3.4c-4.7.6-7.7 3.5-7.7 7.6 0 3.8 2.3 6.2 7.1 7.1l3.9.8c3.1.6 4.3 1.6 4.3 3.3z" opacity="0.85"/>
+  </g>
 </svg>

--- a/client/public/tokens/sol.svg
+++ b/client/public/tokens/sol.svg
@@ -1,15 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <linearGradient id="solGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+    <linearGradient id="solBg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0E1428"/>
+      <stop offset="100%" stop-color="#02040A"/>
+    </linearGradient>
+    <linearGradient id="solStripe" x1="0%" y1="0%" x2="100%" y2="0%">
       <stop offset="0%" stop-color="#14F195"/>
       <stop offset="50%" stop-color="#00FFA3"/>
       <stop offset="100%" stop-color="#8A63D2"/>
     </linearGradient>
+    <linearGradient id="solHighlight" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0"/>
+    </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="12" fill="#0C0D1A"/>
-  <g fill="url(#solGradient)" transform="translate(10 16)">
-    <path d="M34 0H0l6 6h34l-6-6z"/>
-    <path d="M40 14H6l-6 6h34l6-6z"/>
-    <path d="M34 28H0l6 6h34l-6-6z"/>
+  <rect width="64" height="64" rx="16" fill="url(#solBg)"/>
+  <g fill="url(#solStripe)" transform="translate(8 12)">
+    <path d="M44 0H8l6-6h36l-6 6z"/>
+    <path d="M48 18H12l-6 6h36l6-6z"/>
+    <path d="M44 36H8l6-6h36l-6 6z"/>
+  </g>
+  <g fill="url(#solHighlight)" transform="translate(8 12)">
+    <path d="M44 0H8l6-6h36l-6 6z"/>
+    <path d="M48 18H12l-6 6h36l6-6z"/>
+    <path d="M44 36H8l6-6h36l-6 6z"/>
   </g>
 </svg>

--- a/client/public/tokens/usdc.svg
+++ b/client/public/tokens/usdc.svg
@@ -1,5 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <circle cx="32" cy="32" r="32" fill="#2775CA"/>
-  <circle cx="32" cy="32" r="26" fill="none" stroke="#ffffff" stroke-width="4"/>
-  <path fill="#ffffff" d="M28.9 18.5v3.8c-5 1.2-8.4 5.3-8.4 9.7 0 4.4 3.3 8.5 8.4 9.7v3.8h4.2v-3.3c3.5-.3 6.6-1.8 9.1-4.3l-3-3a9.7 9.7 0 01-6 2.7v-7.5c5.5-1.4 8.5-4 8.5-8.4 0-4.4-3.6-7.6-8.5-8.8v-3.4h-4.2zm0 8.1c0-1.6 1.4-2.9 3.1-2.9s3.1 1.3 3.1 2.9c0 1.5-1.2 2.5-3.1 3.2v-6.1zm0 9.3v6.4c-1.9-.7-3.1-2-3.1-3.6 0-1.7 1.2-2.7 3.1-3.3z"/>
+  <defs>
+    <radialGradient id="usdcGradient" cx="50%" cy="35%" r="75%">
+      <stop offset="0%" stop-color="#2D90FF"/>
+      <stop offset="100%" stop-color="#1A5DD9"/>
+    </radialGradient>
+    <linearGradient id="usdcInnerGlow" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.28"/>
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0.08"/>
+    </linearGradient>
+  </defs>
+  <circle cx="32" cy="32" r="30" fill="url(#usdcGradient)"/>
+  <circle cx="32" cy="32" r="28" fill="none" stroke="#FFFFFF" stroke-opacity="0.18" stroke-width="2"/>
+  <circle cx="32" cy="32" r="23" fill="none" stroke="url(#usdcInnerGlow)" stroke-width="6"/>
+  <g fill="#FFFFFF">
+    <path d="M40.6 22.4c-2-1.4-4.4-2.2-7.1-2.2-6.7 0-11.8 4.9-11.8 11.8S26.8 43.8 33.5 43.8c2.7 0 5.1-.7 7.1-2.2l-1.5-3.5c-1.6 1.2-3.5 1.9-5.6 1.9-4.5 0-7.7-3.2-7.7-8.1s3.2-8.1 7.7-8.1c2.1 0 4 .6 5.6 1.9l1.5-3.3z"/>
+    <rect x="20.8" y="20.2" width="3.4" height="23.6" rx="1.7" opacity="0.82"/>
+    <rect x="39.8" y="20.2" width="3.4" height="23.6" rx="1.7" opacity="0.82"/>
+  </g>
 </svg>

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -126,7 +126,7 @@ button:hover { background: var(--brand-secondary, #00cc52); }
 
 .direction-toggle { display: inline-flex; align-items: center; justify-content: center; margin: 2px auto; width: 36px; height: 36px; border-radius: 50%; border: 1px solid rgba(255,255,255,0.08); color: #000; background: rgba(74,74,74,1); }
 .direction-toggle:hover { filter: brightness(1.1); }
-.direction-toggle svg { display: block; }
+.direction-toggle svg { display: block; width: 90%; height: 90%; }
 
 .amount-field { position: relative; width: 100%; }
 .amount-field input { padding-right: 56px; width: 200px; max-width: 100%; }
@@ -149,6 +149,7 @@ button:hover { background: var(--brand-secondary, #00cc52); }
 .token-select { display: inline-flex; align-items: center; gap: 8px; background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0)); border: 1px solid rgba(255,255,255,0.08); border-radius: 999px; padding: 6px 10px; height: 44px; }
 .token-select select { background: transparent; color: #fff; border: none; height: 28px; }
 .token-icon { display: inline-flex; width: 18px; height: 18px; }
+.token-img { width: 100%; height: 100%; object-fit: contain; display: block; }
 
 /* Custom token selector */
 .token-select-wrap { position: relative; }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,7 +5,7 @@ const BRAND_LOGO = "https://cdn.builder.io/api/v1/image/assets%2Fd70091a6f5494e0
 
 function SwapIcon() {
   return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="100%" height="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
       <path d="M7 7h11M7 7l3-3M7 7l3 3M17 17H6m11 0l-3-3m3 3l-3 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
     </svg>
   );


### PR DESCRIPTION
## Summary
- enlarge the swap direction toggle icon so it fills the circular control and keep token badges crisp
- replace the USDC, SOL, ETH, BTC, and kUSD SVG assets with higher fidelity artwork

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3794f76988328b5b185e296a257da