### PR TITLE
Restore branded swap UI and add pools page

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -35,12 +35,14 @@
 .brand-wrap { display: flex; align-items: center; gap: 10px; }
 .brand-name { font-weight: 700; letter-spacing: 0.4px; }
 
-.nav-links { display: flex; gap: 14px; }
-.nav-link { color: #cfd3d8; text-decoration: none; font-weight: 500; }
-.nav-link:hover { color: #fff; }
-.nav-right { display: flex; align-items: center; gap: 12px; }
-.connect-button { background: var(--brand-primary, #00ff66); color: #000; border: none; border-radius: 8px; padding: 8px 12px; font-weight: 700; cursor: pointer; }
-.connect-button:hover { background: var(--brand-secondary, #00cc52); }
+  .nav-links { display: flex; gap: 14px; }
+  .nav-link { color: #cfd3d8; text-decoration: none; font-weight: 500; padding: 6px 10px; border-radius: 999px; transition: 0.2s; }
+  .nav-link:hover { color: #fff; background: rgba(255,255,255,0.06); }
+  .nav-link.is-active { color: #000; background: var(--brand-primary, #00ff66); font-weight: 600; }
+  .nav-right { display: flex; align-items: center; gap: 12px; }
+  .network-chip { padding: 6px 10px; border-radius: 999px; border: 1px solid rgba(255,255,255,0.1); font-size: 12px; color: #cfd3d8; }
+  .connect-button { background: var(--brand-primary, #00ff66); color: #000; border: none; border-radius: 8px; padding: 8px 12px; font-weight: 700; cursor: pointer; }
+  .connect-button:hover { background: var(--brand-secondary, #00cc52); }
 
 .logo { width: 40px; height: 40px; border-radius: 8px; }
 
@@ -191,18 +193,42 @@ button:hover { background: var(--brand-secondary, #00cc52); }
 .pools-section { width: 100%; max-width: 1200px; margin: 0 auto; padding: 0 10px; }
 .section-title { margin: 0 0 14px; text-align: left; }
 .pools-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 14px; }
-.pool-card {
-  background: #141414;
-  border: 1px solid rgba(255,255,255,0.06);
-  border-radius: 12px;
-  padding: 14px;
-  text-align: left;
-}
+  .pool-card {
+    background: #141414;
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 12px;
+    padding: 14px;
+    text-align: left;
+    cursor: pointer;
+  }
+  .pool-card.is-active {
+    border-color: var(--brand-primary, #00ff66);
+    box-shadow: 0 0 0 1px rgba(0,255,102,0.2);
+  }
 .pool-pair { font-weight: 700; margin-bottom: 8px; }
 .pool-metrics { display: flex; gap: 12px; color: #b1b6bd; margin-bottom: 10px; }
 .metric-label { color: #8f949a; margin-right: 4px; }
-.pool-cta { width: auto; background: var(--brand-accent, #5ac8ff); color: #000; padding: 8px 12px; border-radius: 8px; }
-.pool-cta:hover { filter: brightness(0.95); }
+  .pool-cta { width: auto; background: var(--brand-accent, #5ac8ff); color: #000; padding: 8px 12px; border-radius: 8px; display: inline-flex; align-items: center; gap: 6px; }
+  .pool-cta:hover { filter: brightness(0.95); }
+
+  .liquidity-panels {
+    display: grid;
+    gap: 16px;
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+  .liquidity-box h2 { margin-top: 0; }
+  .liquidity-box .field-group { margin-top: 12px; }
+  .liquidity-box input {
+    background: #0f0f0f;
+    border: none;
+    border-radius: 10px;
+    height: 44px;
+    padding: 10px 12px;
+    color: #fff;
+  }
 
 /* Footer */
 .site-footer { margin-top: auto; border-top: 1px solid rgba(255,255,255,0.06); }
@@ -211,22 +237,24 @@ button:hover { background: var(--brand-secondary, #00cc52); }
 .footer-inner a:hover { color: #fff; }
 
 /* Responsive */
-@media (max-width: 1024px) {
-  .pools-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .asset-row { grid-template-columns: repeat(2, 1fr); }
-}
-@media (max-width: 768px) {
-  .stats-strip { grid-template-columns: 1fr; }
-  .nav-links { display: none; }
-  .asset-row { grid-template-columns: 1fr; }
-  .pair-row { grid-template-columns: auto 1fr; align-items: center; padding: 10px; }
-  .token-col { align-items: center; }
-  .token-select { padding: 6px 10px; }
-  .token-select select { font-size: 16px; }
-  .field-label { display: none; }
-  .amount-col input { font-size: 26px; }
-  .direction-toggle { width: 44px; height: 44px; }
-  .swap-controls { display: none; }
-  .pools-grid { grid-template-columns: 1fr; }
-  .swap-box { max-width: 100%; }
-}
+  @media (max-width: 1024px) {
+    .pools-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .liquidity-panels { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .asset-row { grid-template-columns: repeat(2, 1fr); }
+  }
+  @media (max-width: 768px) {
+    .stats-strip { grid-template-columns: 1fr; }
+    .nav-links { display: none; }
+    .asset-row { grid-template-columns: 1fr; }
+    .pair-row { grid-template-columns: auto 1fr; align-items: center; padding: 10px; }
+    .token-col { align-items: center; }
+    .token-select { padding: 6px 10px; }
+    .token-select select { font-size: 16px; }
+    .field-label { display: none; }
+    .amount-col input { font-size: 26px; }
+    .direction-toggle { width: 44px; height: 44px; }
+    .swap-controls { display: none; }
+    .pools-grid { grid-template-columns: 1fr; }
+    .liquidity-panels { grid-template-columns: 1fr; }
+    .swap-box { max-width: 100%; }
+  }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,12 +1,103 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import "./App.css";
+import logo from "./ApeX-logo.png";
+import { applyBrandTheme } from "./theme";
 
-function App() {
+const TOKENS = [
+  { symbol: "APE", name: "ApeX Token" },
+  { symbol: "USDC", name: "USD Coin" },
+  { symbol: "ETH", name: "Ether" },
+  { symbol: "BTC", name: "Wrapped Bitcoin" },
+];
+
+const POOLS = [
+  { id: "APE-USDC", tokenA: "APE", tokenB: "USDC", apr: "18.4%", tvl: "$2.3M" },
+  { id: "APE-ETH", tokenA: "APE", tokenB: "ETH", apr: "14.1%", tvl: "$1.1M" },
+  { id: "ETH-USDC", tokenA: "ETH", tokenB: "USDC", apr: "9.8%", tvl: "$3.7M" },
+  { id: "BTC-USDC", tokenA: "BTC", tokenB: "USDC", apr: "6.2%", tvl: "$4.9M" },
+];
+
+function Header({ view, onNavigate }) {
+  const handleNav = (target, path) => (event) => {
+    event.preventDefault();
+    onNavigate(target, path);
+  };
+
+  return (
+    <header className="top-nav">
+      <div className="brand-wrap">
+        <img src={logo} alt="ApeX" className="logo" />
+        <span className="brand-name">ApeX Swap</span>
+      </div>
+      <nav className="nav-links">
+        <a
+          href="/"
+          className={`nav-link${view === "swap" ? " is-active" : ""}`}
+          onClick={handleNav("swap", "/")}
+        >
+          Swap
+        </a>
+        <a
+          href="/pools"
+          className={`nav-link${view === "pools" ? " is-active" : ""}`}
+          onClick={handleNav("pools", "/pools")}
+        >
+          Pools
+        </a>
+      </nav>
+      <div className="nav-right">
+        <span className="network-chip">Keeta Testnet</span>
+        <button className="connect-button" type="button">
+          Connect Wallet
+        </button>
+      </div>
+    </header>
+  );
+}
+
+function Footer() {
+  return (
+    <footer className="site-footer">
+      <div className="footer-inner">
+        <span>© {new Date().getFullYear()} ApeX Labs</span>
+        <div>
+          <a href="https://apex.exchange" target="_blank" rel="noreferrer">
+            Docs
+          </a>
+          <a href="https://twitter.com" target="_blank" rel="noreferrer">
+            Twitter
+          </a>
+          <a href="https://discord.com" target="_blank" rel="noreferrer">
+            Discord
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+function SwapPage() {
   const [fromAsset, setFromAsset] = useState("APE");
   const [toAsset, setToAsset] = useState("USDC");
   const [amount, setAmount] = useState("");
+  const [wallet, setWallet] = useState("test-wallet");
   const [status, setStatus] = useState("");
 
+  const heroStats = useMemo(
+    () => [
+      { label: "24h Volume", value: "$1.42M" },
+      { label: "Best Route Savings", value: "$32.4K" },
+      { label: "Supported Assets", value: `${TOKENS.length}+` },
+    ],
+    []
+  );
+
   const handleSwap = async () => {
+    if (!amount) {
+      setStatus("Enter an amount to swap");
+      return;
+    }
+
     setStatus("Processing swap...");
 
     try {
@@ -17,49 +108,420 @@ function App() {
           from: fromAsset,
           to: toAsset,
           amount,
-          wallet: "user-wallet-address", // TODO: replace with connected wallet
+          wallet,
         }),
       });
 
       const data = await res.json();
 
       if (res.ok) {
-        setStatus(
-          `Swap complete ✅ TX: ${data.tx.hash}, Output: ${data.outputAmount} ${toAsset}`
-        );
+        const txHash = data?.tx?.hash || data?.tx?.id || "submitted";
+        setStatus(`Swap complete ✅ TX: ${txHash}, Output: ${data.outputAmount} ${toAsset}`);
       } else {
-        setStatus(`Error: ${data.error}`);
+        setStatus(`Error: ${data.error || "Swap failed"}`);
       }
     } catch (err) {
       setStatus(`Request failed: ${err.message}`);
     }
   };
 
+  const handleFlip = () => {
+    setFromAsset(toAsset);
+    setToAsset(fromAsset);
+  };
+
   return (
-    <div className="App">
-      <h1>ApeX Swap</h1>
+    <main className="content-container">
+      <section className="hero-banner">
+        <h1 className="hero-title">Swap instantly with deep ApeX liquidity</h1>
+        <p className="hero-subtitle">
+          Execute cross-chain swaps and synthetic trades with institutional-grade routing.
+        </p>
+        <div className="stats-strip">
+          {heroStats.map((item) => (
+            <div className="stat-item" key={item.label}>
+              <div className="stat-label">{item.label}</div>
+              <div className="stat-value">{item.value}</div>
+            </div>
+          ))}
+        </div>
+      </section>
 
-      <div>
-        <label>From Asset:</label>
-        <input
-          value={fromAsset}
-          onChange={(e) => setFromAsset(e.target.value)}
-        />
+      <section className="swap-section">
+        <div className="swap-box">
+          <div className="swap-header">
+            <div className="swap-controls">
+              <button className="icon-button" type="button" aria-label="Refresh quotes">
+                ↻
+              </button>
+              <div className="slippage-chip">Slippage 0.5%</div>
+            </div>
+          </div>
+
+          <div className="pair-stack">
+            <div className="row-header">Sell</div>
+            <div className="pair-row">
+              <div className="token-col">
+                <div className="token-select">
+                  <span className="token-symbol">{fromAsset}</span>
+                  <select value={fromAsset} onChange={(e) => setFromAsset(e.target.value)}>
+                    {TOKENS.map((token) => (
+                      <option key={token.symbol} value={token.symbol}>
+                        {token.symbol}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="amount-col">
+                <div className="amount-field">
+                  <input
+                    value={amount}
+                    onChange={(e) => setAmount(e.target.value)}
+                    placeholder="0.0"
+                    type="number"
+                  />
+                  <button className="small-action" type="button" onClick={() => setAmount("100")}>
+                    MAX
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <div className="toggle-row">
+              <div className="hr-line" />
+              <button className="direction-toggle" type="button" onClick={handleFlip} aria-label="Switch pair">
+                ⇅
+              </button>
+              <div className="hr-line" />
+            </div>
+
+            <div className="row-header">Buy</div>
+            <div className="pair-row">
+              <div className="token-col">
+                <div className="token-select">
+                  <span className="token-symbol">{toAsset}</span>
+                  <select value={toAsset} onChange={(e) => setToAsset(e.target.value)}>
+                    {TOKENS.map((token) => (
+                      <option key={token.symbol} value={token.symbol}>
+                        {token.symbol}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="amount-col">
+                <div className="field-group">
+                  <div className="balance-line">Best route via ApeX Pools</div>
+                  <div className="route-line">Est. output updates after quote</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="field-group">
+            <label className="field-label" htmlFor="wallet-input">
+              Wallet
+            </label>
+            <input
+              id="wallet-input"
+              value={wallet}
+              onChange={(e) => setWallet(e.target.value)}
+              placeholder="wallet address"
+              type="text"
+            />
+          </div>
+
+          <div className="submit-row">
+            <button className="primary-cta" type="button" onClick={handleSwap}>
+              Review Swap
+            </button>
+          </div>
+
+          {status && <p className="status">{status}</p>}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function PoolsPage() {
+  const [selectedPoolId, setSelectedPoolId] = useState(POOLS[0].id);
+  const selectedPool = useMemo(
+    () => POOLS.find((pool) => pool.id === selectedPoolId) || POOLS[0],
+    [selectedPoolId]
+  );
+
+  const [poolStats, setPoolStats] = useState(null);
+  const [poolStatus, setPoolStatus] = useState("");
+  const [loadingPool, setLoadingPool] = useState(false);
+  const [amountA, setAmountA] = useState("");
+  const [amountB, setAmountB] = useState("");
+  const [lpAmount, setLpAmount] = useState("");
+  const [wallet, setWallet] = useState("test-wallet");
+  const [addStatus, setAddStatus] = useState("");
+  const [removeStatus, setRemoveStatus] = useState("");
+
+  useEffect(() => {
+    let isMounted = true;
+    const loadPool = async () => {
+      setLoadingPool(true);
+      setPoolStatus("");
+      try {
+        const res = await fetch("/.netlify/functions/getpool", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ tokenA: selectedPool.tokenA, tokenB: selectedPool.tokenB }),
+        });
+        const data = await res.json();
+        if (!isMounted) return;
+        if (res.ok) {
+          setPoolStats(data);
+        } else {
+          setPoolStatus(data.error || "Unable to load pool reserves");
+        }
+      } catch (err) {
+        if (isMounted) {
+          setPoolStatus(`Request failed: ${err.message}`);
+        }
+      } finally {
+        if (isMounted) {
+          setLoadingPool(false);
+        }
+      }
+    };
+
+    loadPool();
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedPool]);
+
+  const handleAddLiquidity = async () => {
+    if (!amountA || !amountB) {
+      setAddStatus("Enter amounts for both tokens");
+      return;
+    }
+    setAddStatus("Submitting transaction...");
+    try {
+      const res = await fetch("/.netlify/functions/addLiquidity", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tokenA: selectedPool.tokenA,
+          tokenB: selectedPool.tokenB,
+          amountA,
+          amountB,
+          wallet,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        const txHash = data?.tx?.hash || data?.tx?.id || "submitted";
+        setAddStatus(`Liquidity added ✅ TX: ${txHash}`);
+        setAmountA("");
+        setAmountB("");
+      } else {
+        setAddStatus(`Error: ${data.error || "Add liquidity failed"}`);
+      }
+    } catch (err) {
+      setAddStatus(`Request failed: ${err.message}`);
+    }
+  };
+
+  const handleRemoveLiquidity = async () => {
+    if (!lpAmount) {
+      setRemoveStatus("Enter an LP amount to burn");
+      return;
+    }
+    setRemoveStatus("Submitting transaction...");
+    try {
+      const res = await fetch("/.netlify/functions/removeLiquidity", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tokenA: selectedPool.tokenA,
+          tokenB: selectedPool.tokenB,
+          lpAmount,
+          wallet,
+        }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        const txHash = data?.tx?.hash || data?.tx?.id || "submitted";
+        setRemoveStatus(
+          `Liquidity removed ✅ TX: ${txHash} — Returned ${data.amountA} ${selectedPool.tokenA} & ${data.amountB} ${selectedPool.tokenB}`
+        );
+        setLpAmount("");
+      } else {
+        setRemoveStatus(`Error: ${data.error || "Remove liquidity failed"}`);
+      }
+    } catch (err) {
+      setRemoveStatus(`Request failed: ${err.message}`);
+    }
+  };
+
+  return (
+    <main className="content-container">
+      <section className="hero-banner">
+        <h1 className="hero-title">Provide liquidity. Earn real yield.</h1>
+        <p className="hero-subtitle">
+          Supply assets into ApeX Pools to capture trading fees and protocol rewards.
+        </p>
+        <div className="stats-strip">
+          {POOLS.map((pool) => (
+            <div className="stat-item" key={pool.id}>
+              <div className="stat-label">{pool.tokenA}/{pool.tokenB} APR</div>
+              <div className="stat-value">{pool.apr}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="pools-section">
+        <h2 className="section-title">Available Pools</h2>
+        <div className="pools-grid">
+          {POOLS.map((pool) => (
+            <button
+              type="button"
+              key={pool.id}
+              className={`pool-card${selectedPoolId === pool.id ? " is-active" : ""}`}
+              onClick={() => setSelectedPoolId(pool.id)}
+            >
+              <div className="pool-pair">
+                {pool.tokenA}/{pool.tokenB}
+              </div>
+              <div className="pool-metrics">
+                <span>
+                  <span className="metric-label">APR</span>
+                  {pool.apr}
+                </span>
+                <span>
+                  <span className="metric-label">TVL</span>
+                  {pool.tvl}
+                </span>
+              </div>
+              <div className="pool-cta">Manage position</div>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="swap-section">
+        <div className="liquidity-panels">
+          <div className="swap-box liquidity-box">
+            <h2>Pool Overview</h2>
+            <p className="balance-line">
+              Selected pool: {selectedPool.tokenA}/{selectedPool.tokenB}
+            </p>
+            {loadingPool ? (
+              <p className="status">Fetching reserves...</p>
+            ) : poolStats ? (
+              <div className="info-rows">
+                <div className="info-line">
+                  Reserves: {poolStats.reserveA} {selectedPool.tokenA} / {poolStats.reserveB} {selectedPool.tokenB}
+                </div>
+                <div className="info-line">Pool address: coming soon</div>
+              </div>
+            ) : (
+              <p className="status">{poolStatus}</p>
+            )}
+          </div>
+
+          <div className="swap-box liquidity-box">
+            <h2>Add Liquidity</h2>
+            <div className="field-group">
+              <span className="field-label">Amount {selectedPool.tokenA}</span>
+              <input
+                value={amountA}
+                onChange={(e) => setAmountA(e.target.value)}
+                placeholder="0.0"
+                type="number"
+              />
+            </div>
+            <div className="field-group">
+              <span className="field-label">Amount {selectedPool.tokenB}</span>
+              <input
+                value={amountB}
+                onChange={(e) => setAmountB(e.target.value)}
+                placeholder="0.0"
+                type="number"
+              />
+            </div>
+            <div className="field-group">
+              <span className="field-label">Wallet</span>
+              <input value={wallet} onChange={(e) => setWallet(e.target.value)} placeholder="wallet address" />
+            </div>
+            <button type="button" className="primary-cta" onClick={handleAddLiquidity}>
+              Supply liquidity
+            </button>
+            {addStatus && <p className="status">{addStatus}</p>}
+          </div>
+
+          <div className="swap-box liquidity-box">
+            <h2>Remove Liquidity</h2>
+            <div className="field-group">
+              <span className="field-label">LP Tokens to Burn</span>
+              <input
+                value={lpAmount}
+                onChange={(e) => setLpAmount(e.target.value)}
+                placeholder="0.0"
+                type="number"
+              />
+            </div>
+            <div className="field-group">
+              <span className="field-label">Wallet</span>
+              <input value={wallet} onChange={(e) => setWallet(e.target.value)} placeholder="wallet address" />
+            </div>
+            <button type="button" className="primary-cta" onClick={handleRemoveLiquidity}>
+              Withdraw liquidity
+            </button>
+            {removeStatus && <p className="status">{removeStatus}</p>}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function App() {
+  const [view, setView] = useState(() =>
+    typeof window !== "undefined" && window.location.pathname.toLowerCase().includes("pools")
+      ? "pools"
+      : "swap"
+  );
+
+  useEffect(() => {
+    applyBrandTheme(logo).catch(() => {
+      /* ignore theme errors */
+    });
+  }, []);
+
+  useEffect(() => {
+    const handlePop = () => {
+      const next = window.location.pathname.toLowerCase().includes("pools") ? "pools" : "swap";
+      setView(next);
+    };
+    window.addEventListener("popstate", handlePop);
+    return () => window.removeEventListener("popstate", handlePop);
+  }, []);
+
+  const handleNavigate = (target, path) => {
+    if (typeof window !== "undefined") {
+      if (window.location.pathname !== path) {
+        window.history.pushState({}, "", path);
+      }
+      setView(target);
+    }
+  };
+
+  return (
+    <div className="app">
+      <div className="site-shell">
+        <Header view={view} onNavigate={handleNavigate} />
+        {view === "pools" ? <PoolsPage /> : <SwapPage />}
+        <Footer />
       </div>
-
-      <div>
-        <label>To Asset:</label>
-        <input value={toAsset} onChange={(e) => setToAsset(e.target.value)} />
-      </div>
-
-      <div>
-        <label>Amount:</label>
-        <input value={amount} onChange={(e) => setAmount(e.target.value)} />
-      </div>
-
-      <button onClick={handleSwap}>Swap</button>
-
-      <p>{status}</p>
     </div>
   );
 }

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -3,7 +3,10 @@ import App from "./App";
 
 test("renders swap interface", () => {
   render(<App />);
-  expect(screen.getByText(/trade digital assets seamlessly/i)).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: /connect/i })).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: /swap/i })).toBeInTheDocument();
+  expect(
+    screen.getByText(/swap instantly with deep ApeX liquidity/i)
+  ).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /connect wallet/i })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /review swap/i })).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: /pools/i })).toBeInTheDocument();
 });

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,13 +1,19 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+    "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+    "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: var(--brand-bg, #0f0f0f);
+  color: #fff;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+  font-family: "Source Code Pro", Menlo, Monaco, Consolas, "Courier New",
     monospace;
+}
+
+#root {
+  min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- rebuild the React shell with a branded header, hero statistics, and manual navigation between the swap and pools views
- add a dedicated pools experience that fetches reserve data and wires add/remove liquidity actions to the Netlify functions
- refresh styling and typography for the swap and pools screens and update the regression test to reflect the new copy

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d45113c46483289f3a19a135fe91ae