### PR TITLE
Add shared CORS handling for Netlify functions

### DIFF
--- a/functions/addLiquidity.js
+++ b/functions/addLiquidity.js
@@ -1,11 +1,12 @@
 // functions/addLiquidity.js
 import * as KeetaNet from "@keetanetwork/keetanet-client";
+import { withCors } from "./cors.js";
 
 /**
  * Add liquidity to a pool
  * Input: { tokenA, tokenB, amountA, amountB, wallet }
  */
-export async function handler(event) {
+const baseHandler = async (event) => {
   try {
     const { tokenA, tokenB, amountA, amountB, wallet } = JSON.parse(event.body || "{}");
 
@@ -30,4 +31,6 @@ export async function handler(event) {
   } catch (err) {
     return { statusCode: 500, body: JSON.stringify({ error: err.message }) };
   }
-}
+};
+
+export const handler = withCors(baseHandler);

--- a/functions/cors.js
+++ b/functions/cors.js
@@ -1,0 +1,87 @@
+const DEFAULT_ALLOWED_ORIGINS = ["https://builder.io"];
+
+function parseEnvOrigins() {
+  const value = process.env.CORS_ALLOWED_ORIGINS;
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+const ENV_ALLOWED_ORIGINS = parseEnvOrigins();
+
+const FLY_ORIGIN_REGEX = /^https:\/\/[a-z0-9-]+\.fly\.dev$/i;
+
+function resolveAllowedOrigin(requestOrigin) {
+  if (!requestOrigin) {
+    return DEFAULT_ALLOWED_ORIGINS[0];
+  }
+
+  if (DEFAULT_ALLOWED_ORIGINS.includes(requestOrigin)) {
+    return requestOrigin;
+  }
+
+  if (ENV_ALLOWED_ORIGINS.includes(requestOrigin)) {
+    return requestOrigin;
+  }
+
+  if (FLY_ORIGIN_REGEX.test(requestOrigin)) {
+    return requestOrigin;
+  }
+
+  return null;
+}
+
+function buildCorsHeaders(requestOrigin) {
+  const allowedOrigin = resolveAllowedOrigin(requestOrigin);
+
+  if (!allowedOrigin) {
+    return null;
+  }
+
+  return {
+    "Access-Control-Allow-Origin": allowedOrigin,
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+  };
+}
+
+export function withCors(handler) {
+  return async function corsWrappedHandler(event, context) {
+    const originHeader = event?.headers?.origin || event?.headers?.Origin;
+    const corsHeaders = buildCorsHeaders(originHeader);
+
+    if (event.httpMethod === "OPTIONS") {
+      if (!corsHeaders) {
+        return { statusCode: 403, body: "CORS origin not allowed" };
+      }
+
+      return {
+        statusCode: 204,
+        headers: {
+          ...corsHeaders,
+          "Access-Control-Max-Age": "600",
+        },
+        body: "",
+      };
+    }
+
+    const response = await handler(event, context);
+
+    if (!corsHeaders) {
+      return response;
+    }
+
+    return {
+      ...response,
+      headers: {
+        ...(response.headers || {}),
+        ...corsHeaders,
+      },
+    };
+  };
+}

--- a/functions/getpool.js
+++ b/functions/getpool.js
@@ -1,11 +1,12 @@
 // functions/getPool.js
 import * as KeetaNet from "@keetanetwork/keetanet-client";
+import { withCors } from "./cors.js";
 
 /**
  * Get pool reserves for two tokens
  * Input: { tokenA, tokenB }
  */
-export async function handler(event) {
+const baseHandler = async (event) => {
   try {
     const { tokenA, tokenB } = JSON.parse(event.body || "{}");
 
@@ -28,4 +29,6 @@ export async function handler(event) {
   } catch (err) {
     return { statusCode: 500, body: JSON.stringify({ error: err.message }) };
   }
-}
+};
+
+export const handler = withCors(baseHandler);

--- a/functions/removeLiquidity.js
+++ b/functions/removeLiquidity.js
@@ -1,11 +1,12 @@
 // functions/removeLiquidity.js
 import * as KeetaNet from "@keetanetwork/keetanet-client";
+import { withCors } from "./cors.js";
 
 /**
  * Remove liquidity from a pool
  * Input: { tokenA, tokenB, lpAmount, wallet }
  */
-export async function handler(event) {
+const baseHandler = async (event) => {
   try {
     const { tokenA, tokenB, lpAmount, wallet } = JSON.parse(event.body || "{}");
 
@@ -31,4 +32,6 @@ export async function handler(event) {
   } catch (err) {
     return { statusCode: 500, body: JSON.stringify({ error: err.message }) };
   }
-}
+};
+
+export const handler = withCors(baseHandler);

--- a/functions/swap.js
+++ b/functions/swap.js
@@ -1,4 +1,5 @@
 import * as KeetaNet from "@keetanetwork/keetanet-client";
+import { withCors } from "./cors.js";
 
 // Constant product AMM formula
 function getOutputAmount(inputAmount, reserveIn, reserveOut) {
@@ -8,7 +9,7 @@ function getOutputAmount(inputAmount, reserveIn, reserveOut) {
   return numerator / denominator;
 }
 
-export async function handler(event) {
+const baseHandler = async (event) => {
   try {
     const { from, to, amount, wallet } = JSON.parse(event.body || "{}");
 
@@ -41,4 +42,6 @@ export async function handler(event) {
       body: JSON.stringify({ error: err.message }),
     };
   }
-}
+};
+
+export const handler = withCors(baseHandler);


### PR DESCRIPTION
## Summary
- add a reusable CORS wrapper that whitelists Builder.io, Fly.io domains, and optional env overrides for Netlify functions
- wrap each Netlify function handler with the CORS helper to respond to OPTIONS preflight requests and attach headers on success or error responses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d469cb64488328b0020295913f8383